### PR TITLE
order bug

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -50,6 +50,8 @@ export const ADD_CARD_START = 'ADD_CARD_START';
 export const ADD_CARD_SUCCESS = 'ADD_CARD_SUCCESS';
 export const DELETE_CARD_START = 'DELETE_CARD_START';
 export const DELETE_CARD_SUCCESS = 'DELETE_CARD_SUCCESS';
+export const UPDATE_ORDER_START = 'UPDATE_ORDER_START';
+export const UPDATE_ORDER_SUCCESS = 'UPDATE_ORDER_SUCCESS';
 
 // login for vendors
 export const loginAndGetVendor = (credentials) => (dispatch) => {
@@ -72,7 +74,7 @@ export const loginAndGetDiner = (credentials) => (dispatch) => {
   dispatch({ type: GET_DINER_START });
   axios
     .post(
-      "http://localhost:5000/api/auth/login/diners",
+      "https://foodtrucktrackr.herokuapp.com/api/auth/login/diners",
       credentials
     )
     .then((res) => {
@@ -90,7 +92,7 @@ export const registerDiner = (info) => (dispatch) => {
   console.log(`front end req.body: {name: ${info.name}, username: ${info.username}, email: ${info.email}, password: ${info.password}}`);
   axios
     .post(
-      "http://localhost:5000/api/auth/register/diners",
+      "https://foodtrucktrackr.herokuapp.com/api/auth/register/diners",
       info
     )
     .then((res) => {
@@ -290,4 +292,9 @@ export const deleteCreditCard = (dinerId) => dispatch => {
       dispatch({ type: DELETE_CARD_SUCCESS })
     })
     .catch(err => console.log(err))
+}
+
+export const updateOrder = item => dispatch => {
+  dispatch({ type: UPDATE_ORDER_START })
+  dispatch({ type: UPDATE_ORDER_SUCCESS, payload: item })
 }

--- a/client/src/components/MenuItemModal.js
+++ b/client/src/components/MenuItemModal.js
@@ -7,7 +7,7 @@ import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
 import CurrencyFormatter from "currencyformatter.js";
 
 // action imports
-import { addItemToOrder, openOrderCard, addTruckToOrder } from "../actions";
+import { addItemToOrder, openOrderCard, addTruckToOrder, updateOrder } from "../actions";
 
 const useStyles = makeStyles((theme) => ({
     paper: {
@@ -38,6 +38,14 @@ const MenuItemModal = props => {
     // holds value for count of menu item
     const [count, setCount] = useState(1);
 
+    useEffect(() => {
+        setCount(props.order.some(el => props.menuItem.name === el.item) ? getExistingCount(props.order) : 1)
+    }, [props.menuItem])
+
+    const getExistingCount = (arr) => {
+       return arr.find(el => props.menuItem.name === el.item).count
+    }
+
     // holds value for selected menu item to add to order
     const [itemToAdd, setItemToAdd] = useState({});
 
@@ -58,7 +66,7 @@ const MenuItemModal = props => {
     // closes modal and resets (menu item) count to 1
     const closeAndReset = () => {
         props.closeModal();
-        setCount(1);
+        setCount(30);
     }
 
     // adds item to order 
@@ -72,7 +80,11 @@ const MenuItemModal = props => {
             props.showNewOrderAlert();
             props.closeModal();
         } else {
-            props.addItemToOrder(itemToAdd);
+            if (props.order.some(el => itemToAdd.item === el.item)) {
+                props.updateOrder(itemToAdd);
+            } else {
+                props.addItemToOrder(itemToAdd);
+            }
             props.openOrderCard();
             props.closeModal();
             setCount(1);
@@ -91,10 +103,6 @@ const MenuItemModal = props => {
     useEffect(() => {
         console.log(`count: ${count}`);
     }, [count])
-
-    // const handleSpecialInstructions = () => {
-    //     set
-    // }
 
     return (
         <div>
@@ -133,4 +141,4 @@ const mapStateToProps = state => {
     }
 }
 
-export default connect(mapStateToProps, { addItemToOrder, openOrderCard, addTruckToOrder })(MenuItemModal);
+export default connect(mapStateToProps, { addItemToOrder, openOrderCard, addTruckToOrder, updateOrder })(MenuItemModal);

--- a/client/src/components/TruckMenu.js
+++ b/client/src/components/TruckMenu.js
@@ -120,7 +120,7 @@ const TruckMenu = props => {
                         <Grid container spacing={2}>
                             {menu.entrees.map(item => (
                                     <Grid item xs={4} onClick={() => setMenuItem({ id: item.id, name: item.name, description: item.description, image: item.image, price: item.price })}>
-                                        <Card className="menu-deets-card" onClick={openModal}>
+                                        <Card className={props.order.some(el => item.name === el.item) ? "menu-deets-card-inactive" : "menu-deets-card"} onClick={openModal}>
                                             <div className="menu-deets-cont">
                                                 <p className="menu-item-name">{item.name}</p>
                                                 <p className="menu-item-description">{item.description}</p>
@@ -143,7 +143,7 @@ const TruckMenu = props => {
                         <Grid container spacing={2}>
                             {menu.sides.map(item => (
                                 <Grid item xs={4} onClick={() => setMenuItem({ id: item.id, name: item.name, name: item.name, description: item.description, image: item.image, price: item.price })}>
-                                    <Card className="menu-deets-card" onClick={openModal}>
+                                    <Card className={props.order.some(el => item.name === el.item) ? "menu-deets-card-inactive" : "menu-deets-card"} onClick={openModal}>
                                         <div className="menu-deets-cont">
                                             <p className="menu-item-name">{item.name}</p>
                                             <p className="menu-item-description">{item.description}</p>
@@ -166,7 +166,7 @@ const TruckMenu = props => {
                         <Grid container spacing={2}>
                             {menu.drinks.map(item => (
                                 <Grid item xs={4} onClick={() => setMenuItem({ name: item.name, description: item.description, image: item.image, price: item.price })}>
-                                    <Card className="menu-deets-card" onClick={openModal}>
+                                    <Card className={props.order.some(el => item.name === el.item) ? "menu-deets-card-inactive" : "menu-deets-card"} onClick={openModal}>
                                         <div className="menu-deets-cont">
                                             <p className="menu-item-name">{item.name}</p>
                                             <p className="menu-item-description">{item.description}</p>
@@ -193,7 +193,8 @@ const TruckMenu = props => {
 const mapStateToProps = state => {
     return {
         selectedTruck: state.selectedTruck,
-        orderCardOpen: state.orderCardOpen
+        orderCardOpen: state.orderCardOpen,
+        order: state.order
     }
 }
 

--- a/client/src/reducers/truck-reducer.js
+++ b/client/src/reducers/truck-reducer.js
@@ -43,7 +43,9 @@ import {
   ADD_CARD_START,
   ADD_CARD_SUCCESS,
   DELETE_CARD_START,
-  DELETE_CARD_SUCCESS
+  DELETE_CARD_SUCCESS,
+  UPDATE_ORDER_START,
+  UPDATE_ORDER_SUCCESS
 } from "../actions";
 
 const initialState = {
@@ -369,6 +371,23 @@ export const truckReducer = (state = initialState, action) => {
           ...state.account,
           cardOnFile: null
         }
+      }
+    case UPDATE_ORDER_START:
+      return {
+        ...state,
+        isLoading: true
+      }
+    case UPDATE_ORDER_SUCCESS:
+      // let newOrder = state.order.filter(item => {return item.item !== action.payload})
+      return {
+        ...state,
+        isLoading: false,
+        order: [
+          ...state.order.filter((item) => {
+            return item.item !== action.payload.item;
+          }),
+          action.payload
+        ]
       }
     default:
       return state;

--- a/client/src/styling/TruckMenu.scss
+++ b/client/src/styling/TruckMenu.scss
@@ -39,6 +39,15 @@
     border-radius: 0 !important;
 }
 
+.menu-deets-card-inactive {
+    display: flex;
+    height: 120px;
+    border: 1px solid #eb7530;
+    width: 100%;
+    border-radius: 0 !important;
+    // background: lightgray !important;
+}
+
 .menu-deets-cont {
     width: 70%;
     padding-top: 4%;


### PR DESCRIPTION
Fixed bug that allowed user to add multiple objects of same item to order. For example, if a user added fries to an order. Before, if they went back and tried to add fries again, two different objects of fries would show up in their order. Now, if the user does this, it will just update the count of the fries object as opposed to adding a whole new object. 